### PR TITLE
Fix age filter edge case

### DIFF
--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -21,8 +21,14 @@ const Search: React.FC = () => {
 
   // Debounced filters
   const debouncedBreeds = useDebounce(filterBreeds, 500);
-  const debouncedMinAge = useDebounce(minAge ? Number(minAge) : undefined, 500);
-  const debouncedMaxAge = useDebounce(maxAge ? Number(maxAge) : undefined, 500);
+  const debouncedMinAge = useDebounce(
+    minAge !== '' ? Number(minAge) : undefined,
+    500
+  );
+  const debouncedMaxAge = useDebounce(
+    maxAge !== '' ? Number(maxAge) : undefined,
+    500
+  );
 
   // Results state
   const [dogs, setDogs] = useState<Dog[]>([]);


### PR DESCRIPTION
## Summary
- handle 0 value for age filters so it is not ignored

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850559c275c832a84e661745bb61adf