### PR TITLE
Fix routing base for GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import './index.css';
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <div className="min-h-screen bg-gray-100">
         <h1 className="text-3xl font-bold text-center py-4">Fetch Dog Adoption</h1>
         <Routes>


### PR DESCRIPTION
## Summary
- ensure `BrowserRouter` uses Vite's base URL for GitHub Pages deployment

