### PR TITLE
Update README for cookie setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ To publish the production build to GitHub Pages run:
 npm run deploy
 ```
 This script builds the app and pushes the `dist` directory to the `gh-pages` branch. The site will be available at `https://<your-github-username>.github.io/fetch/`.
+
+### Browser note
+If you visit the app at [https://viiewss.github.io/fetch/](https://viiewss.github.io/fetch/), Chrome may block the authentication cookie. Enable third-party cookies in Chrome (or allow them for this site) so the login token can be stored.


### PR DESCRIPTION
## Summary
- add a note to enable third-party cookies in Chrome for the GitHub Pages site

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68505eb318e4832aa48b11a512eec5a9